### PR TITLE
Making the short-term text forecast optional.

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ conf.registerGlobalValue(Weather,'apiKey', registry.String('', ("""Your wundergr
 conf.registerChannelValue(Weather,'useImperial', registry.Boolean(True, ("""Use imperial units? Defaults to yes.""")))
 conf.registerChannelValue(Weather,'disableColoredTemp', registry.Boolean(False, """If True, this will disable coloring temperatures based on values."""))
 # conf.registerChannelValue(Weather,'useWeatherSymbols', registry.Boolean(False, """Use unicode symbols with weather conditions and for wind direction."""))
+conf.registerGlobalValue(Weather,'daycast', registry.Boolean(True, ("""Display daycast in output by default?""")))
 conf.registerGlobalValue(Weather,'forecast', registry.Boolean(True, ("""Display forecast in output by default?""")))
 conf.registerGlobalValue(Weather,'alerts', registry.Boolean(False, ("""Display alerts by default?""")))
 conf.registerGlobalValue(Weather,'almanac', registry.Boolean(False, ("""Display almanac by default?""")))


### PR DESCRIPTION
Instead of making the text-based short-term forecast display each time, a user setting and switch is added called daycast, used as you would the forecast option.

I'm not a programmer at all but I can sometimes read code and move it around, or add things, to make it work a certain way. Please forgive any basic errors, I generally don't know what I'm doing.

I had to add the sqlite column by hand, it didn't seem to alter the table and add the column automatically - I don't know what I missed to have it add the new column automatically.
