### PR TITLE
test.py: Show a specific error if the apiKey is not set

### DIFF
--- a/test.py
+++ b/test.py
@@ -14,6 +14,11 @@ class WeatherTestCase(PluginTestCase):
     def setUp(self):
         PluginTestCase.setUp(self)
         apiKey = os.environ.get('apiKey')
+        if not apiKey:
+            e = """The Wunderground API key has not been set. 
+            please set this value correctly and try again:
+            'export apiKey=<key>' for bash users"""
+            raise Exception(e)
         conf.supybot.plugins.Weather.apiKey.setValue(apiKey)
 
     def testWeather(self):


### PR DESCRIPTION
This was why the builds for #5 were failing, not because of the code I changed.

This patch makes it clearer for anyone running `supybot-test` in the future to know that it's the lack of an apikey causing the plugin to fail, _not_ their code changes. Without this, the tests just choke with a TypeError as Wunderground doesn't send a reply without a key.
