### PR TITLE
Default showImperialAndMetric to True

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,7 +30,7 @@ conf.registerGlobalValue(Weather,'astronomy', registry.Boolean(False, ("""Displa
 conf.registerGlobalValue(Weather,'showPressure', registry.Boolean(False, ("""Show pressure in output?""")))
 conf.registerGlobalValue(Weather,'showWind', registry.Boolean(False, ("""Show wind in output?""")))
 conf.registerGlobalValue(Weather,'showUpdated', registry.Boolean(False, ("""Show updated in output?""")))
-conf.registerChannelValue(Weather,'showImperialAndMetric', registry.Boolean(False, ("""In channel, display output with Imperial and Metric?""")))
+conf.registerChannelValue(Weather,'showImperialAndMetric', registry.Boolean(True, ("""In channel, display output with Imperial and Metric?""")))
 conf.registerGlobalValue(Weather,'lang', registry.String('EN', ("""language to use. See docs for available codes.""")))
 
 


### PR DESCRIPTION
I am seeing multiple users wondering about the output being in
Fahrenhait and I believe multiple people would be confused if it was
showing only Celsius, so it's probably the best to show both by default.
