### PR TITLE
__init__.py: Fix tests on Python 3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ reload(plugin)
 # reloaded when this plugin is reloaded.  Don't forget to import them as well!
 
 if world.testing:
-    import test
+    from . import test
 
 Class = plugin.Class
 configure = config.configure


### PR DESCRIPTION
Python 3 will completely ignore the tests without this, because implicit relative imports (`import test`) are invalid.

edit: fyi, the builds for this PR show as failing because Travis does not set any environment variables (in this case, used for the API Key) for pull requests.